### PR TITLE
Shortening the link to link to the vlog videos playlist. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The goal of this project is to create a minecraft server hosting system which co
 
 # Building in Public
 
-I'm trying to document this project via my youtube channel [https://www.youtube.com/c/webdevjunkie](https://www.youtube.com/c/webdevjunkie) on this specific youtube series found here: [https://www.youtube.com/watch?v=dBUHBrYB_bQ&list=PL6x5Q-Sj_BlYlBoxMa_jo7LO3OSUhhbru&index=1](https://www.youtube.com/watch?v=dBUHBrYB_bQ&list=PL6x5Q-Sj_BlYlBoxMa_jo7LO3OSUhhbru&index=1).
+I'm trying to document this project via my youtube channel [https://www.youtube.com/c/webdevjunkie](https://www.youtube.com/c/webdevjunkie) on this specific youtube series found here: [https://www.youtube.com/watch?v=dBUHBrYB_bQ&list=PL6x5Q-Sj_BlYlBoxMa_jo7LO3OSUhhbru&index=1](https://bit.ly/minecraftvlogseries).
 
 # Getting Started
 


### PR DESCRIPTION
# Related Issue/Addition to code
- I think that this link is very long https://www.youtube.com/watch?v=dBUHBrYB_bQ&list=PL6x5Q-Sj_BlYlBoxMa_jo7LO3OSUhhbru&index=1 to be linked in README.md, so I adjusted it with a bit.ly link which I just created.

## Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Proposed Changes
- Update link preview to link to vlog series to https://bit.ly/minecraftvlogseries instead of https://www.youtube.com/watch?v=dBUHBrYB_bQ&list=PL6x5Q-Sj_BlYlBoxMa_jo7LO3OSUhhbru&index=1

# Additional Info
- @codyseibert You have your website, you can link it directly instead of going through bit.ly, a third party source via a redirect like https://webdevjunkie.com/minecraftvlogseries or anything else, bit.ly has most of the stuff taken, but that's not a restriction with using your own domain. 

# Screenshots

Original | Updated
:----------------------:|:-----------:
** original screenshot  | ** updated screenshot **

**Not inculding screenshots for this PR**