### PR TITLE
Fix/Format Docsify link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Read a more in detailed documentation on our docsify page (here)[https://codyseibert.github.io/fire-stone-hosting]
+Read a more in detailed documentation on our docsify page [here](https://codyseibert.github.io/fire-stone-hosting)
 
 # What is this project?
 - The goal of this project is to create a minecraft server hosting system which could potentially be used as a real product to rent out minecraft servers to other people.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Read a more in detailed documentation on our docsify page: (https://codyseibert.github.io/fire-stone-hosting)[https://codyseibert.github.io/fire-stone-hosting]
+Read a more in detailed documentation on our docsify page (here)[https://codyseibert.github.io/fire-stone-hosting]
 
 # What is this project?
 - The goal of this project is to create a minecraft server hosting system which could potentially be used as a real product to rent out minecraft servers to other people.


### PR DESCRIPTION
The link must be like this [https://codyseibert.github.io/fire-stone-hosting](https://codyseibert.github.io/fire-stone-hosting] not (https://codyseibert.github.io/fire-stone-hosting)[https://codyseibert.github.io/fire-stone-hosting].

You can just make that change. But I'm making this PR to format the link more better. So that when they click here, it will take them to the page.

